### PR TITLE
Fix sorting NVMe devices

### DIFF
--- a/anolis/8.6/install.env/common
+++ b/anolis/8.6/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/anolis/8.6/install.sh
+++ b/anolis/8.6/install.sh
@@ -66,7 +66,7 @@ sleep 2m
 # Create partitions.
 default_device=/dev/mmcblk0
 # if [ -b /dev/nvme0n1 ]; then
-#     default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+#     default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 # fi
 device=${device:-"$default_device"}
 root_device=${device/\/dev\/}p3

--- a/centos/7.6/install.env/common
+++ b/centos/7.6/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/centos/7.6/install.sh
+++ b/centos/7.6/install.sh
@@ -64,7 +64,7 @@ fi
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-    default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+    default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 root_device=${device/\/dev\/}p3

--- a/ctyunos/23.01/install.env/common
+++ b/ctyunos/23.01/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/ctyunos/23.01/install.sh
+++ b/ctyunos/23.01/install.sh
@@ -61,7 +61,7 @@ fi
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 root_device=${device/\/dev\/}p3

--- a/debian/11/install.sh
+++ b/debian/11/install.sh
@@ -255,7 +255,7 @@ log "INFO: $distro installation started"
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-        default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+        default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 

--- a/debian/12/install.env/common
+++ b/debian/12/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/debian/12/install.sh
+++ b/debian/12/install.sh
@@ -62,7 +62,7 @@ fi
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 root_device=${device/\/dev\/}p2

--- a/openeuler/20.03sp1/install.env/common
+++ b/openeuler/20.03sp1/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/openeuler/20.03sp1/install.sh
+++ b/openeuler/20.03sp1/install.sh
@@ -61,7 +61,7 @@ fi
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 root_device=${device/\/dev\/}p3

--- a/oraclelinux/8/install.sh
+++ b/oraclelinux/8/install.sh
@@ -386,7 +386,7 @@ SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 root_device=${device/\/dev\/}p2

--- a/rockylinux/8.6/install.env/common
+++ b/rockylinux/8.6/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/rockylinux/8.6/install.sh
+++ b/rockylinux/8.6/install.sh
@@ -61,7 +61,7 @@ fi
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 root_device=${device/\/dev\/}p3

--- a/ubuntu/20.04/install.env/common
+++ b/ubuntu/20.04/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/ubuntu/20.04/install.sh
+++ b/ubuntu/20.04/install.sh
@@ -63,7 +63,7 @@ fi
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 BOOT_PARTITION=${device}p1

--- a/ubuntu/22.04/install.env/common
+++ b/ubuntu/22.04/install.env/common
@@ -275,8 +275,8 @@ prepare_target_partitions()
 	if [ "$SHRED_DRIVES" == "yes" ]; then
 		if [ -x /usr/bin/shred ]; then
 			if [ -b /dev/nvme0n1 ]; then
-				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
-				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)" &
+				log "Shredding /dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
+				shred -n 1 -v "/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)" &
 			fi
 			if [ -b /dev/mmcblk0 ]; then
 				log "Shredding /dev/mmcblk0"

--- a/ubuntu/22.04/install.sh
+++ b/ubuntu/22.04/install.sh
@@ -63,7 +63,7 @@ fi
 
 default_device=/dev/mmcblk0
 if [ -b /dev/nvme0n1 ]; then
-	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -n | tail -1)"
+	default_device="/dev/$(cd /sys/block; /bin/ls -1d nvme* | sort -V | tail -1)"
 fi
 device=${device:-"$default_device"}
 BOOT_PARTITION=${device}p1


### PR DESCRIPTION
Currently if install.sh is choosing NVMe drive as target, it will sort it with '-n' - which is an issue is more then 10 drives are available in the system (0,1,10,11,12,..2,20,21...). Change the sort param so drives are sorted correctly and always the last one was choosen.