### PR TITLE
Fix hardcoded BMC CEC and FW version number

### DIFF
--- a/oraclelinux/8/Dockerfile.run
+++ b/oraclelinux/8/Dockerfile.run
@@ -137,5 +137,3 @@ RUN mkdir -p /etc/ssh/sshd_config.d; echo "PermitRootLogin yes" > /etc/ssh/sshd_
 RUN echo 'omit_drivers+=" mlx5_core mlx5_ib ib_umad "' > /etc/dracut.conf.d/mlnx.conf
 
 RUN /usr/bin/systemctl enable kdump.service
-
-CMD [ "bash", "-c", "/root/workspace/run_create_bfb"]

--- a/oraclelinux/8/bfb-build
+++ b/oraclelinux/8/bfb-build
@@ -45,6 +45,9 @@ DOCA_VERSION="2.8.0"
 BSP_VERSION="4.8.0-13249"
 BF_VERSION=${BSP_VERSION%-*}
 IMAGE_TYPE=${IMAGE_TYPE:-"prod"}
+BF3_BMC_VERSION="24.07-14"
+BF3_CEC_VERSION="00.02.0182.0000"
+BF3_NIC_FW_VERSION="32_42_1000"
 RELTARGET="24.07"
 BUILDVER=${BUILDVER:-"64"}
 
@@ -53,6 +56,14 @@ BASE_URL=${BASE_URL:-"https://linux.mellanox.com/public/repo"}
 LEAVE_CONTAINER=${LEAVE_CONTAINER:-"no"}
 
 mkdir -p $WDIR
+
+# Add select env variables that will be passed into container during run phase
+cat > ${WDIR}/envfile << EOF
+BSP_VERSION=${BSP_VERSION}
+BF3_BMC_VERSION=${BF3_BMC_VERSION}
+BF3_CEC_VERSION=${BF3_CEC_VERSION}
+BF3_NIC_FW_VERSION=${BF3_NIC_FW_VERSION}
+EOF
 
 mkdir -p $WDIR/bootimages
 wget -P $WDIR/bootimages -r --no-verbose --no-directories -l1 --no-parent -A 'mlxbf-bootimages*.aarch64.rpm' ${BASE_URL}/bluefield/${BSP_VERSION}/bootimages/${IMAGE_TYPE}/
@@ -134,7 +145,8 @@ DOCKER_RUN_PARAMS="--privileged -e container=docker \
 	--name BlueField_OS_${DISTRO}_${DISTRO_VERSION} \
 	--mount type=bind,source=/dev,target=/dev \
 	--mount type=bind,source=/sys,target=/sys \
-	--mount type=bind,source=/proc,target=/proc"
+	--mount type=bind,source=/proc,target=/proc \
+	--env-file envfile"
 
 if [ "X${LEAVE_CONTAINER}" == "Xyes" ]; then
 	DOCKER_RUN_PARAMS="-d -it ${DOCKER_RUN_PARAMS}"

--- a/oraclelinux/8/run_create_bfb
+++ b/oraclelinux/8/run_create_bfb
@@ -23,10 +23,11 @@ do
 		/bin/rm -f /workspace/BF3BMC/bmc/*
 		/bin/rm -f /workspace/BF3BMC/cec/*
 		/bin/rm -f /workspace/BF3BMC/golden_images/dpu/*
-		wget -P /workspace/BF3BMC/bmc -q --no-check-certificate ${BMC_URL}/bmc/24.04-6/bf3-bmc-24.04-6_opn.fwpkg
-		wget -P /workspace/BF3BMC/cec -q --no-check-certificate ${BMC_URL}/cec/00.02.0182.0000/cec1736-ecfw-00.02.0182.0000-n02-rel-prod.fwpkg
-		wget -P /workspace/BF3BMC/golden_images/dpu -q --no-check-certificate ${BMC_URL}/golden_images/dpu/4.7.0-13127/BlueField-GA-4.7.0.13127_preboot-install.bfb
-		wget -P /workspace/BF3BMC/golden_images/fw -q --no-check-certificate -r --no-directories -l1 --no-parent -A 'fw*bfb' ${BMC_URL}/golden_images/nic-fw/32_41_1300/
+		echo "Downloading BlueField-3 BMC software..."
+		wget -P /workspace/BF3BMC/bmc -r --no-directories -l1 --no-parent -A 'bf3-bmc*fwpkg' ${BMC_URL}/bmc/${BF3_BMC_VERSION}/
+		wget -P /workspace/BF3BMC/cec -r --no-directories -l1 --no-parent -A 'cec*fwpkg' ${BMC_URL}/cec/${BF3_CEC_VERSION}/
+		wget -P /workspace/BF3BMC/golden_images/dpu -r --no-verbose --no-directories -l1 --no-parent -A 'BlueField*.bfb' ${BMC_URL}/golden_images/dpu/${BSP_VERSION}/
+		wget -P /workspace/BF3BMC/golden_images/fw -r --no-verbose --no-directories -l1 --no-parent -A 'fw*.bfb' ${BMC_URL}/golden_images/nic-fw/${BF3_NIC_FW_VERSION}/
 		;;
 	*)
 		type=unsigned


### PR DESCRIPTION
Pull request for two commits:
Dockerfile.run: Remove duplicated run_create_bfb command
run_create_bfb: Replace hardcoded version number with environment variables