### PR TITLE
Fix RHEL9.6 OVS download function

### DIFF
--- a/rhel/9.6/Dockerfile
+++ b/rhel/9.6/Dockerfile
@@ -10,12 +10,14 @@ ARG BMC_FW_PACKAGES="bf2-bmc-fw-signed bf3-bmc-fw-signed bf3-bmc-gi-signed bf3-b
 ARG CEC_FW_PACKAGES="bf2-cec-fw-signed bf3-cec-fw-signed"
 
 ADD bootimages bootimages/
+ADD dependencies dependencies/
 ADD 10-mlx-console-messages.conf /etc/sysctl.d/
 ADD install.env /root/workspace/install.env/
 ADD install.sh create_bfb /root/workspace/
 ADD repos/ /etc/yum.repos.d/
 
 RUN rpm -ihv --force bootimages/mlxbf-bootimages-*.aarch64.rpm || true
+RUN rpm -ihv --force dependencies/*.rpm || true
 
 RUN echo 'excludepkgs=OpenIPMI strongswan*el9' >> /etc/dnf/dnf.conf && \
     rm -f /etc/sysconfig/network-scripts/ifcfg-enp1s0 /etc/NetworkManager/system-connections/enp1s0.nmconnection /etc/yum.repos.d/ubi.repo && \

--- a/rhel/9.6/bfb-build
+++ b/rhel/9.6/bfb-build
@@ -74,9 +74,10 @@ esac
 mkdir -p $WDIR/bootimages
 wget --no-verbose -P $WDIR/bootimages ${BASE_URL}/doca/${DOCA_VERSION}/${DISTRO}${DISTRO_VERSION}${DISTRO_KERNEL}/${ARCH}/$bootimages
 
+mkdir -p $WDIR/dependencies
 echo "Downloading doca-openvswitch-ipsec..."
 OPENVSWITCH_IPSEC_PATTERN="doca-openvswitch-ipsec.*rpm$"
-download_files_by_pattern "${BASE_URL}/doca/${DOCA_VERSION}/${DISTRO}${DISTRO_VERSION}${DISTRO_KERNEL}/${ARCH}" "$OPENVSWITCH_IPSEC_PATTERN"
+download_files_by_pattern "${BASE_URL}/doca/${DOCA_VERSION}/${DISTRO}${DISTRO_VERSION}${DISTRO_KERNEL}/${ARCH}" "$OPENVSWITCH_IPSEC_PATTERN" "$WDIR/dependencies"
 
 cp -a \
 	Dockerfile \


### PR DESCRIPTION
RHEL9.6 requires doca-openvswitch-ipsec to be installed seperately. The function responsible for downloading the package does download it but creates a hang right after blocking the execution of the script.

This change changes the function to look for a single package per every call where a pattern is provided (meaning it will download the first package that matches the pattern).