### PR TITLE
Fix script failure on download counter increment

### DIFF
--- a/common/functions.sh
+++ b/common/functions.sh
@@ -43,7 +43,7 @@ download_files_by_pattern() {
         if [[ -n "$filename" ]]; then
             echo "Downloading: $filename"
             if wget -q -P "$target_dir" "${base_url}/${filename}"; then
-                ((download_count++))
+                ((++download_count))
             else
                 echo "Warning: Failed to download $filename" >&2
             fi


### PR DESCRIPTION
Command `((download_count++))` uses postfix operator that evaluates the arithmetic expression to `0` that as per Bash results in exit status `1`. This prematurely exits the `bfb-build` script. Changing it to `((++download_count))` does not change the functionality but fixes the script exit.